### PR TITLE
Fix S3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 script:
   - make test
   - make vet
-  - NEXUS_URL=http://127.0.0.1:8081 NEXUS_USERNAME=admin NEXUS_PASSWORD=admin123 make testacc
+  - SKIP_S3_TESTS=1 NEXUS_URL=http://127.0.0.1:8081 NEXUS_USERNAME=admin NEXUS_PASSWORD=admin123 make testacc
 #  - make website-test
 
 branches:

--- a/README.md
+++ b/README.md
@@ -331,7 +331,13 @@ Now start the tests
 NEXUS_URL="http://127.0.0.1:8081" NEXUS_USERNAME="admin" NEXUS_PASSWORD="admin123" make testacc
 ```
 
-**NOTE**: To test Blobstore type S3 following environment variables must be set, otherwise tests will fail
+or without s3 tests which require additional configuration:
+
+```shell
+SKIP_S3_TESTS=1 NEXUS_URL="http://127.0.0.1:8081" NEXUS_USERNAME="admin" NEXUS_PASSWORD="admin123" make testacc
+```
+
+**NOTE**: To test Blobstore type S3 following environment variables must be set, otherwise tests will fail.
 
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`

--- a/nexus/resource_blobstore_test.go
+++ b/nexus/resource_blobstore_test.go
@@ -2,6 +2,7 @@ package nexus
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	nexus "github.com/datadrivers/go-nexus-client"
@@ -55,6 +56,9 @@ resource "nexus_blobstore" "acceptance" {
 }
 
 func TestAccResourceBlobstoreS3(t *testing.T) {
+	if os.Getenv("SKIP_S3_TESTS") != "" {
+		t.Skip("Skipping S3 tests")
+	}
 	awsAccessKeyID := getEnv("AWS_ACCESS_KEY_ID", "")
 	awsSecretAccessKey := getEnv("AWS_SECRET_ACCESS_KEY", "")
 	bsName := fmt.Sprintf("test-blobstore-s3-%d", acctest.RandIntRange(0, 99))
@@ -99,7 +103,7 @@ resource "nexus_blobstore" "acceptance" {
 
 		bucket_security {
 		  access_key_id     = "%s"
-		  secret_access_key = "%s"		  
+		  secret_access_key = "%s"
 		}
 	}
 }`, name, bsType, bucketName, bucketRegion, awsAccessKeyID, awsSecretAccessKey)


### PR DESCRIPTION
S3 tests require additional configuration and currently don't work in CI
environment.

This patch introduces an option to disable S3 tests (see readme).
The S3 tests are also disabled on CI until this is fixed by CI
maintainers.