### PR TITLE
Add make darwin-build-install command

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,6 +23,9 @@ linux: fmtcheck
 darwin: fmtcheck
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o terraform.d/plugins/darwin_amd64/terraform-provider-nexus -v
 
+darwin-build-install: fmtcheck
+	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(GOBUILD) -o ~/.terraform.d/plugins/darwin_amd64/terraform-provider-nexus -v
+
 test: fmtcheck
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \

--- a/README.md
+++ b/README.md
@@ -315,6 +315,14 @@ There is a [makefile](./GNUmakefile) to build the provider.
 make
 ```
 
+To build and install provider on macOS into `~/.terraform.d/plugins/darwin_amd64`, you can run
+
+```sh
+make darwin-build-install
+```
+
+In this case provider will be available to use with your terraform codebase (in terraform init stage).
+
 ## Testing
 
 For testing start a local Docker container using script [./scripts/start-nexus.sh](./scripts/start-nexus.sh).


### PR DESCRIPTION
Currently make darwin command will build and save provider in current
folder, but to make it available in terraform it should be put under
home directory.

This patch adds another make command to build and install provider into
~/.terraform.d/plugins/darwin_amd64