### PR TITLE
Fix Travis errors and warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: bionic
-sudo: required
+os: linux
 services:
   - docker
 language: go
@@ -24,7 +24,7 @@ branches:
   only:
     - master
 
-matrix:
+jobs:
   fast_finish: true
   allow_failures:
     - go: tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
 branches:
   only:
     - master
+    - develop
 
 jobs:
   fast_finish: true


### PR DESCRIPTION
This change will fix following config validation warnings:
- root: deprecated key sudo (The key `sudo` has no effect anymore.)
- root: missing os, using the default linux
- root: key matrix is an alias for jobs, using jobs